### PR TITLE
Update timeNow to check post every second

### DIFF
--- a/public/javascripts/ngDirectives/timeNowDirective.js
+++ b/public/javascripts/ngDirectives/timeNowDirective.js
@@ -12,13 +12,12 @@ angular.module('demo').directive('timeNow', ['dateFilter', '$timeout', 'timeFunc
             var updateTime = function() {
                 var now = new Date();
                 element.html(dateFilter(now.valueOf(), format));
-                if(now.getHours() !== 0 && now.getMinutes()%5 === 0 && now.getSeconds() === 0) {
-                    console.log(now.getHours(), now.getMinutes(), now.getSeconds(), 'every 5 minutes?');
+                if(now.getHours() !== 0) {
+                    console.log(now.getHours(), now.getMinutes(), 'every second...');
                     mainFty.updatePost(now);
-                 } else if(now.getHours() === 0 && now.getMinutes() === 0) {
-                    console.log(now.getHours(), now.getMinutes(), now.getSeconds(), 'every day?');
+                } else if(now.getHours() === 0 && now.getMinutes() === 0) {
+                    console.log(now.getHours(), now.getMinutes(), 'every day...');
                     mainFty.updateDate(now);
-                    mainFty.updatePost(now);
                 }
                 $timeout(updateTime, 1000);
             }

--- a/public/javascripts/ngServices/mainFactory.js
+++ b/public/javascripts/ngServices/mainFactory.js
@@ -131,7 +131,7 @@ angular.module('demo').factory('mainFty', function() {
             var timeMDY =   selectedTime.getFullYear()+
                             selectedTime.getMonth()+
                             selectedTime.getDay();
-            var opHM =      selectedTime.getHours()+
+            var opHM =      (selectedTime.getHours()*100)+
                             selectedTime.getMinutes();
             var onePost = {};
             onePost.timeObject = selectedTime;
@@ -179,11 +179,11 @@ angular.module('demo').factory('mainFty', function() {
             }
         },
         updatePost: function(tbObjectIn) {
-            var tbHMin = tbObjectIn.getHours()+tbObjectIn.getMinutes();
+            var tbHMin = (tbObjectIn.getHours()*100)+tbObjectIn.getMinutes();
             
             if(displayTFuture.length>0) {
                 for(var i=displayTFuture.length-1, c=0; i>=c; i--){
-                    if(displayTFuture[i].HM === tbHMin ){
+                    if(displayTFuture[i].HM <= tbHMin){
                         displayTPast.push(displayTFuture.pop());
                     } else break;
                 }
@@ -217,7 +217,11 @@ angular.module('demo').factory('mainFty', function() {
             if(displayFuture.length>0 && lastFuture.MDY === tbMYDin) {
                 lastFuture = displayFuture.pop();
                 for(var i=0, c=lastFuture.messages.length; i<c; i++) {
-                    displayTFuture.push(lastFuture.messages[i]);
+                    if(lastFuture.messages[i].HM === 0) {
+                        displayTPast.push(lastFuture.messages[i]);
+                    } else {
+                        displayTFuture.push(lastFuture.messages[i]);      
+                    }
                 }
             }
         }

--- a/server/views/index.ejs
+++ b/server/views/index.ejs
@@ -54,7 +54,7 @@
     <!-- PAST -->
     </section>
     
-    <!-- SCRIPT - jQuery FROM GOOGLE CDN -->
+    <!-- SCRIPT - jQuery FROM SERVER -->
     <script src="/javascripts/jquery-1.11.3.js"></script>
     <!-- SCRIPT - STATIC CONTENT FROM SERVER -->
     <script src="/app.js"></script>


### PR DESCRIPTION
timeNowDirective.js
- check for post every second instead of every 5 minutes to prevent timeline insync with current time when browser is off focus.
- updatePost now will move all today's future post array that is earlier than current time will move to today's past post array instead only the time that match with current time to prevent timeline insync.

index.ejs
- correct comment which jquery now is request from server instead from Google CDN.
